### PR TITLE
Fix Error with governance_quorum

### DIFF
--- a/lib/genesisd.py
+++ b/lib/genesisd.py
@@ -65,7 +65,7 @@ class GenesisDaemon():
 
     def governance_quorum(self):
         # TODO: expensive call, so memoize this
-        total_masternodes = self.rpc_command('masternode', 'count', 'enabled')
+        total_masternodes = self.rpc_command('masternode', 'count')['enabled']
         min_quorum = self.govinfo['governanceminquorum']
 
         # the minimum quorum is calculated based on the number of masternodes


### PR DESCRIPTION
The node is reporting that `masternode count` no longer allows the third parameter of `enabled`. This change queries just `masternode count` and receives a dictionary, then uses the `enabled` element within, allowing sentinel to execute without failure.